### PR TITLE
docs: clarify installers and checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,24 @@
 - Optional Ctrl+Shift accents on number row for compact boards.
 
 **Install (Windows)**
-1. Download `Pinka_amd64.msi` (64-bit) or run `setup.exe`.
+1. If you're unsure, run `setup.exe`; it detects your architecture and installs the right package. Use a specific `.msi` for manual or unattended setups:
+   - `Pinka_amd64.msi` for 64-bit x64 systems
+   - `Pinka_i386.msi` for 32-bit x86 systems
+   - `Pinka_ia64.msi` for Itanium systems
 2. Settings → Time & Language → Language → Keyboard → add **Pinka**.
-3. Switch with Win+Space.  
+3. Switch with Win+Space.
    Note: on Windows, **AltGr = Right Alt = Ctrl+Alt**. If an app uses Ctrl+Alt shortcuts, rebind them.
 
 **Uninstall**: Apps → Installed apps → Pinka → Uninstall.
 
 **Verify download**
-Use PowerShell: `Get-FileHash .\Pinka_amd64.msi -Algorithm SHA256`.
+Use PowerShell to check the SHA256 of the installer you downloaded:
+
+```
+Get-FileHash .\Pinka_amd64.msi -Algorithm SHA256
+Get-FileHash .\Pinka_i386.msi -Algorithm SHA256
+Get-FileHash .\Pinka_ia64.msi -Algorithm SHA256
+Get-FileHash .\setup.exe -Algorithm SHA256
+```
 
 **License**: MIT.


### PR DESCRIPTION
## Summary
- detail when to run `setup.exe` versus architecture-specific `.msi` packages
- list all installer variants, including `Pinka_i386.msi` and `Pinka_ia64.msi`
- show SHA256 verification commands for every installer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b44eb5fe2c83259b2bd011ee329c8a