### PR TITLE
Ensure admin rights for install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,12 @@
+#Requires -RunAsAdministrator
 param(
     [switch]$Quiet
 )
+
+if (-not ([Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))) {
+    Write-Error "This script must be run as Administrator."
+    exit 1
+}
 
 # Determine system architecture
 $arch = (Get-CimInstance Win32_OperatingSystem).OSArchitecture

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,6 +1,12 @@
+#Requires -RunAsAdministrator
 param(
     [switch]$Quiet
 )
+
+if (-not ([Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))) {
+    Write-Error "This script must be run as Administrator."
+    exit 1
+}
 
 # Determine system architecture
 $arch = (Get-CimInstance Win32_OperatingSystem).OSArchitecture


### PR DESCRIPTION
## Summary
- Require running install/uninstall scripts with administrator privileges
- Add explicit elevation checks with helpful error messages

## Testing
- ❌ `pwsh -NoLogo -NoProfile -File ./install.ps1` (pwsh not installed)
- ⚠️ `apt-get install -y powershell` (package not found)


------
https://chatgpt.com/codex/tasks/task_e_68b463d035c483258553cbc8132b9829