### PR TITLE
Check MSI installer exit codes

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -26,4 +26,8 @@ if ($Quiet) {
     $arguments += " /qn"
 }
 
-Start-Process -FilePath "msiexec.exe" -ArgumentList $arguments -Wait
+$process = Start-Process -FilePath "msiexec.exe" -ArgumentList $arguments -Wait -PassThru
+if ($process.ExitCode -ne 0) {
+    Write-Error "Installer exited with code $($process.ExitCode)"
+}
+exit $process.ExitCode

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -26,4 +26,8 @@ if ($Quiet) {
     $arguments += " /qn"
 }
 
-Start-Process -FilePath "msiexec.exe" -ArgumentList $arguments -Wait
+$process = Start-Process -FilePath "msiexec.exe" -ArgumentList $arguments -Wait -PassThru
+if ($process.ExitCode -ne 0) {
+    Write-Error "Installer exited with code $($process.ExitCode)"
+}
+exit $process.ExitCode


### PR DESCRIPTION
## Summary
- capture Start-Process handles in install/uninstall scripts
- forward installer exit codes and report failures

## Testing
- `pwsh -NoLogo -NoProfile -File ./install.ps1 -Quiet` *(fails: Get-CimInstance not recognized)*
- `pwsh -NoLogo -NoProfile -File ./uninstall.ps1 -Quiet` *(fails: Get-CimInstance not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68b463d971b0832588870636a42cdf35