### PR TITLE
refactor: centralize MSI path helper

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2,20 +2,9 @@ param(
     [switch]$Quiet
 )
 
-# Determine system architecture
-$arch = (Get-CimInstance Win32_OperatingSystem).OSArchitecture
+. "$PSScriptRoot/scripts/common.ps1"
 
-switch -regex ($arch) {
-    '64' { $msi = 'Pinka_amd64.msi' }
-    '32' { $msi = 'Pinka_i386.msi' }
-    'Itanium|IA64' { $msi = 'Pinka_ia64.msi' }
-    default {
-        Write-Error "Unsupported architecture: $arch"
-        exit 1
-    }
-}
-
-$msiPath = Join-Path $PSScriptRoot $msi
+$msiPath = Get-PinkaMsi
 if (-not (Test-Path $msiPath)) {
     Write-Error "Installer $msiPath not found."
     exit 1

--- a/scripts/common.ps1
+++ b/scripts/common.ps1
@@ -1,0 +1,13 @@
+function Get-PinkaMsi {
+    $arch = (Get-CimInstance Win32_OperatingSystem).OSArchitecture
+
+    switch -regex ($arch) {
+        '64' { $msi = 'Pinka_amd64.msi' }
+        '32' { $msi = 'Pinka_i386.msi' }
+        'Itanium|IA64' { $msi = 'Pinka_ia64.msi' }
+        default { throw "Unsupported architecture: $arch" }
+    }
+
+    $root = Split-Path $PSScriptRoot -Parent
+    return (Join-Path $root $msi)
+}

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -2,20 +2,9 @@ param(
     [switch]$Quiet
 )
 
-# Determine system architecture
-$arch = (Get-CimInstance Win32_OperatingSystem).OSArchitecture
+. "$PSScriptRoot/scripts/common.ps1"
 
-switch -regex ($arch) {
-    '64' { $msi = 'Pinka_amd64.msi' }
-    '32' { $msi = 'Pinka_i386.msi' }
-    'Itanium|IA64' { $msi = 'Pinka_ia64.msi' }
-    default {
-        Write-Error "Unsupported architecture: $arch"
-        exit 1
-    }
-}
-
-$msiPath = Join-Path $PSScriptRoot $msi
+$msiPath = Get-PinkaMsi
 if (-not (Test-Path $msiPath)) {
     Write-Error "Installer $msiPath not found."
     exit 1


### PR DESCRIPTION
## Summary
- Create shared scripts/common.ps1 with Get-PinkaMsi for architecture-based MSI path lookup
- Refactor install.ps1 and uninstall.ps1 to use helper

## Testing
- `pwsh -NoLogo -NoProfile -Command '. "$PWD/scripts/common.ps1"; Get-PinkaMsi'` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b463da35dc8325bbd80a5669be2173