### PR TITLE
docs: add SHA256 checksums for releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,14 @@ Get-FileHash .\Pinka_ia64.msi -Algorithm SHA256
 Get-FileHash .\setup.exe -Algorithm SHA256
 ```
 
+**SHA256 checksums**
+
+| File | SHA256 |
+| --- | --- |
+| Pinka_amd64.msi | 02124b3d8fb281be65fda6a07e0a9bffeb306260bc025c4ad8be77b50db29615 |
+| Pinka_i386.msi  | 0602c20fb7f722d9f9d32ac9931f656eb76dc1f5937caf02a06c38c6dcacdfa2 |
+| Pinka_ia64.msi  | 99ba7ccc826d11aca828255ad426dafe539a35fde66352c4b492fd54b001cd93 |
+| setup.exe       | 26e455d1953fe77a034f3bd53fc2bbe8caf22de2f6c9e53b03cd7cb0685feeef |
+| pinka.zip       | 2cacb3851625ecb326365cca63c34859228d121d1a04895e1451d0949272be4f |
+
 **License**: MIT.


### PR DESCRIPTION
## Summary
- document SHA256 hashes for packaged releases in README

## Testing
- `sha256sum -c dist/SHA256SUMS`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b463daefc88325ac7cdefba1761fb8