### PR TITLE
docs: display logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pinka — QWERTY + AltGr for Hungarian
 
+![Pinka logo](pinka_transparent.png)
+
 **Goal:** full Hungarian on US QWERTY without relearning keys.
 
 **Features**


### PR DESCRIPTION
## Summary
- show Pinka logo at top of README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b468160cd083258364c4940a5e6103