### PR TITLE
Add macOS Pinka keyboard layout bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Named after the [Pinka river](https://en.wikipedia.org/wiki/Pinka)—the only ri
 4. Switch with Win+Space.
    Note: on Windows, **AltGr = Right Alt = Ctrl+Alt**. If an app uses Ctrl+Alt shortcuts, rebind them.
 
+**Install (macOS)**
+1. Copy `macos/Pinka.bundle` to `/Library/Keyboard Layouts/` (for all users) or `~/Library/Keyboard Layouts/` (just for the current user).
+   - Optional: convert `pinka_transparent.png` to `Pinka.icns` with Preview or `iconutil`
+     and place it in `macos/Pinka.bundle/Contents/Resources` before copying if you want a custom icon.
+2. Log out and back in so macOS loads the new layout.
+3. Open **System Settings → Keyboard → Input Sources** and click **+** to add **Pinka**.
+4. Switch layouts with the menu bar keyboard switcher or `Ctrl+Space`.
+
 **Uninstall**: run `uninstall.ps1` (add `-Quiet` for silent) or Apps → Installed apps → Pinka → Uninstall.
 
 **Verify download**

--- a/macos/Pinka.bundle/Contents/Info.plist
+++ b/macos/Pinka.bundle/Contents/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.example.Pinka</string>
+  <key>CFBundleName</key>
+  <string>Pinka</string>
+  <key>CFBundleDisplayName</key>
+  <string>Pinka</string>
+  <key>CFBundlePackageType</key>
+  <string>KbdL</string>
+  <key>CFBundleVersion</key>
+  <string>1.0</string>
+  <key>CFBundleSignature</key>
+  <string>????</string>
+  <key>CFBundleSupportedPlatforms</key>
+  <array>
+    <string>MacOSX</string>
+  </array>
+  <key>NSHumanReadableCopyright</key>
+  <string>Copyright © 2024 Pinka contributors</string>
+</dict>
+</plist>

--- a/macos/Pinka.bundle/Contents/Resources/Pinka.keylayout
+++ b/macos/Pinka.bundle/Contents/Resources/Pinka.keylayout
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE keyboard SYSTEM "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
+<keyboard group="0" id="-25313" name="Pinka">
+  <layouts>
+    <layout first="0" last="0" modifiers="default" keyMapSet="0"/>
+  </layouts>
+  <modifierMap defaultIndex="0">
+    <keyMapSelect mapIndex="0"/>
+    <keyMapSelect mapIndex="1" shift="any"/>
+    <keyMapSelect mapIndex="2" option="any"/>
+    <keyMapSelect mapIndex="3" option="any" shift="any"/>
+  </modifierMap>
+  <keyMapSet id="0">
+    <!-- Base -->
+    <keyMap index="0">
+      <key code="0" output="a"/>
+      <key code="1" output="s"/>
+      <key code="2" output="d"/>
+      <key code="3" output="f"/>
+      <key code="4" output="h"/>
+      <key code="5" output="g"/>
+      <key code="6" output="z"/>
+      <key code="7" output="x"/>
+      <key code="8" output="c"/>
+      <key code="9" output="v"/>
+      <key code="11" output="b"/>
+      <key code="12" output="q"/>
+      <key code="13" output="w"/>
+      <key code="14" output="e"/>
+      <key code="15" output="r"/>
+      <key code="16" output="y"/>
+      <key code="17" output="t"/>
+      <key code="18" output="1"/>
+      <key code="19" output="2"/>
+      <key code="20" output="3"/>
+      <key code="21" output="4"/>
+      <key code="22" output="6"/>
+      <key code="23" output="5"/>
+      <key code="24" output="="/>
+      <key code="25" output="9"/>
+      <key code="26" output="7"/>
+      <key code="27" output="-"/>
+      <key code="28" output="8"/>
+      <key code="29" output="0"/>
+      <key code="30" output="]"/>
+      <key code="31" output="o"/>
+      <key code="32" output="u"/>
+      <key code="33" output="["/>
+      <key code="34" output="i"/>
+      <key code="35" output="p"/>
+      <key code="37" output="l"/>
+      <key code="38" output="j"/>
+      <key code="39" output="'"/>
+      <key code="40" output="k"/>
+      <key code="41" output=";"/>
+      <key code="42" output="\\"/>
+      <key code="43" output=","/>
+      <key code="44" output="/"/>
+      <key code="45" output="n"/>
+      <key code="46" output="m"/>
+      <key code="47" output="."/>
+      <key code="49" output=" "/>
+      <key code="50" output="`"/>
+    </keyMap>
+    <!-- Shift -->
+    <keyMap index="1">
+      <key code="0" output="A"/>
+      <key code="1" output="S"/>
+      <key code="2" output="D"/>
+      <key code="3" output="F"/>
+      <key code="4" output="H"/>
+      <key code="5" output="G"/>
+      <key code="6" output="Z"/>
+      <key code="7" output="X"/>
+      <key code="8" output="C"/>
+      <key code="9" output="V"/>
+      <key code="11" output="B"/>
+      <key code="12" output="Q"/>
+      <key code="13" output="W"/>
+      <key code="14" output="E"/>
+      <key code="15" output="R"/>
+      <key code="16" output="Y"/>
+      <key code="17" output="T"/>
+      <key code="18" output="!"/>
+      <key code="19" output="@"/>
+      <key code="20" output="#"/>
+      <key code="21" output="$"/>
+      <key code="22" output="^"/>
+      <key code="23" output="%"/>
+      <key code="24" output="+"/>
+      <key code="25" output="("/>
+      <key code="26" output="&amp;"/>
+      <key code="27" output="_"/>
+      <key code="28" output="*"/>
+      <key code="29" output=")"/>
+      <key code="30" output="}"/>
+      <key code="31" output="O"/>
+      <key code="32" output="U"/>
+      <key code="33" output="{"/>
+      <key code="34" output="I"/>
+      <key code="35" output="P"/>
+      <key code="37" output="L"/>
+      <key code="38" output="J"/>
+      <key code="39" output="\"/>
+      <key code="40" output="K"/>
+      <key code="41" output=":"/>
+      <key code="42" output="|"/>
+      <key code="43" output="&lt;"/>
+      <key code="44" output="?"/>
+      <key code="45" output="N"/>
+      <key code="46" output="M"/>
+      <key code="47" output="&gt;"/>
+      <key code="49" output=" "/>
+      <key code="50" output="~"/>
+    </keyMap>
+    <!-- Option (AltGr) -->
+    <keyMap index="2">
+      <key code="0" output="á"/>
+      <key code="1" output="ß"/>
+      <key code="5" output="gy"/>
+      <key code="12" output="ä"/>
+      <key code="14" output="é"/>
+      <key code="30" output="ű"/>
+      <key code="31" output="ó"/>
+      <key code="32" output="ú"/>
+      <key code="33" output="ő"/>
+      <key code="34" output="í"/>
+      <key code="37" output="ly"/>
+      <key code="39" output="ü"/>
+      <key code="41" output="ö"/>
+      <key code="45" output="ny"/>
+    </keyMap>
+    <!-- Option + Shift -->
+    <keyMap index="3">
+      <key code="0" output="Á"/>
+      <key code="1" output="ẞ"/>
+      <key code="5" output="Gy"/>
+      <key code="12" output="Ä"/>
+      <key code="14" output="É"/>
+      <key code="30" output="Ű"/>
+      <key code="31" output="Ó"/>
+      <key code="32" output="Ú"/>
+      <key code="33" output="Ő"/>
+      <key code="34" output="Í"/>
+      <key code="37" output="Ly"/>
+      <key code="39" output="Ü"/>
+      <key code="41" output="Ö"/>
+      <key code="45" output="Ny"/>
+    </keyMap>
+  </keyMapSet>
+</keyboard>


### PR DESCRIPTION
## Summary
- add macOS Pinka.bundle with keylayout and metadata
- document optional generation of icon for macOS layout

## Testing
- `xmllint --noout macos/Pinka.bundle/Contents/Resources/Pinka.keylayout`
- `xmllint --noout macos/Pinka.bundle/Contents/Info.plist`


------
https://chatgpt.com/codex/tasks/task_e_68b47a73d1b483259a1e8f617bb40ca0