### PR TITLE
Add Linux XKB layout and install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ Named after the [Pinka river](https://en.wikipedia.org/wiki/Pinka)—the only ri
 3. Open **System Settings → Keyboard → Input Sources** and click **+** to add **Pinka**.
 4. Switch layouts with the menu bar keyboard switcher or `Ctrl+Space`.
 
-**Uninstall**: run `uninstall.ps1` (add `-Quiet` for silent) or Apps → Installed apps → Pinka → Uninstall.
+**Install (Linux)**
+1. Run `sudo ./install.sh` to copy the layout to `/usr/share/X11/xkb/` and register it.
+2. Add **Pinka** in your desktop environment's keyboard settings.
+3. Switch layouts with your usual shortcut.
+
+**Uninstall**
+- Windows: run `uninstall.ps1` (add `-Quiet` for silent) or Apps → Installed apps → Pinka → Uninstall.
+- Linux: run `sudo ./uninstall.sh`.
 
 **Verify download**
 SHA256 checksums are provided in `dist/SHA256SUMS` and on the releases page. Use PowerShell to verify the installer you downloaded:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+  echo "This script must be run as root." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+symbols_src="$SCRIPT_DIR/linux/symbols/pinka"
+rules_snippet="$SCRIPT_DIR/linux/rules/evdev.xml"
+symbols_dst="/usr/share/X11/xkb/symbols/pinka"
+rules_dst="/usr/share/X11/xkb/rules/evdev.xml"
+
+install -D -m 0644 "$symbols_src" "$symbols_dst"
+
+if ! grep -q '<name>pinka</name>' "$rules_dst"; then
+  perl -0 -i -pe "s|</layoutList>|$(printf '%s\n' "$(cat "$rules_snippet")")\n</layoutList>|m" "$rules_dst"
+fi
+
+echo "Pinka layout installed. Log out and back in or restart to apply."
+

--- a/linux/rules/evdev.xml
+++ b/linux/rules/evdev.xml
@@ -1,0 +1,12 @@
+<layout>
+  <configItem>
+    <name>pinka</name>
+    <shortDescription>Pinka</shortDescription>
+    <description>Pinka</description>
+    <languageList>
+      <iso639Id>hun</iso639Id>
+      <iso639Id>ger</iso639Id>
+      <iso639Id>eng</iso639Id>
+    </languageList>
+  </configItem>
+</layout>

--- a/linux/symbols/pinka
+++ b/linux/symbols/pinka
@@ -1,0 +1,22 @@
+partial alphanumeric_keys
+xkb_symbols "pinka" {
+    name[Group1] = "Pinka";
+
+    include "us(basic)"
+    include "level3(ralt_switch)"
+
+    key <AC01> { [ a, A, aacute, Aacute ] };
+    key <AC02> { [ s, S, ssharp, U1E9E ] };
+    key <AC05> { [ g, G, string "gy", string "Gy" ] };
+    key <AD01> { [ q, Q, adiaeresis, Adiaeresis ] };
+    key <AD03> { [ e, E, eacute, Eacute ] };
+    key <AD12> { [ bracketright, braceright, uhungarumlaut, Uhungarumlaut ] };
+    key <AD09> { [ o, O, oacute, Oacute ] };
+    key <AD07> { [ u, U, uacute, Uacute ] };
+    key <AD11> { [ bracketleft, braceleft, ohungarumlaut, Ohungarumlaut ] };
+    key <AD08> { [ i, I, iacute, Iacute ] };
+    key <AC09> { [ l, L, string "ly", string "Ly" ] };
+    key <AC11> { [ apostrophe, quotedbl, udiaeresis, Udiaeresis ] };
+    key <AC10> { [ semicolon, colon, odiaeresis, Odiaeresis ] };
+    key <AB06> { [ n, N, string "ny", string "Ny" ] };
+};

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+  echo "This script must be run as root." >&2
+  exit 1
+fi
+
+symbols_dst="/usr/share/X11/xkb/symbols/pinka"
+rules_dst="/usr/share/X11/xkb/rules/evdev.xml"
+
+rm -f "$symbols_dst"
+
+if grep -q '<name>pinka</name>' "$rules_dst"; then
+  perl -0 -i -pe 's|\n?\s*<layout>\n\s*<configItem>\n\s*<name>pinka</name>.*?\n\s*</layout>||ms' "$rules_dst"
+fi
+
+echo "Pinka layout removed."
+


### PR DESCRIPTION
## Summary
- Add XKB symbols file and rules snippet for the Pinka layout on Linux
- Provide bash install/uninstall scripts for deploying the layout
- Document Linux installation steps in README

## Testing
- `bash -n install.sh`
- `bash -n uninstall.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b4d014a7788325a388361c70e4a425