### PR TITLE
Assign macOS bundle identifier and signature

### DIFF
--- a/macos/Pinka.bundle/Contents/Info.plist
+++ b/macos/Pinka.bundle/Contents/Info.plist
@@ -5,7 +5,7 @@
   <key>CFBundleDevelopmentRegion</key>
   <string>en</string>
   <key>CFBundleIdentifier</key>
-  <string>com.example.Pinka</string>
+  <string>io.github.odriwalter.Pinka</string>
   <key>CFBundleName</key>
   <string>Pinka</string>
   <key>CFBundleDisplayName</key>
@@ -15,7 +15,7 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>CFBundleSignature</key>
-  <string>????</string>
+  <string>PINK</string>
   <key>CFBundleSupportedPlatforms</key>
   <array>
     <string>MacOSX</string>


### PR DESCRIPTION
## Summary
- replace placeholder bundle identifier with `io.github.odriwalter.Pinka`
- set macOS bundle signature to `PINK`

## Testing
- `xmllint --noout macos/Pinka.bundle/Contents/Info.plist`
- `bash -n install.sh`
- `bash -n uninstall.sh`
- (fails: `plutil -lint macos/Pinka.bundle/Contents/Info.plist` command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b4d5e54a3c832598dfb2456a1397f0